### PR TITLE
Fix Dynamic Area is distroyed.

### DIFF
--- a/src/SampSharp.Streamer.Entities/Components/DynamicArea.cs
+++ b/src/SampSharp.Streamer.Entities/Components/DynamicArea.cs
@@ -83,7 +83,7 @@ namespace SampSharp.Streamer.Entities
         /// <inheritdoc />
         protected override void OnDestroyComponent()
         {
-            GetComponent<NativeDynamicTextLabel>().DestroyDynamic3DTextLabel();
+            GetComponent<NativeDynamicArea>().DestroyDynamicArea();
         }
     }
 }


### PR DESCRIPTION
When a dynamic area is distroyed the inherited method OnDestroyComponent is calling to NativeDynamicTextLabel instead of NativeDynamicArea.